### PR TITLE
Custom encoder option

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,7 @@
 module github.com/chowey/jsonrpc
 
 go 1.13
+
+require github.com/helloeave/json v0.0.0-00010101000000-000000000000
+
+replace github.com/helloeave/json => github.com/homelight/json v1.13.0

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,2 @@
+github.com/homelight/json v1.13.0 h1:W1r5BUfQhgN6lGbu2YRXenSSPdbsJj8Gc+PV3PN+Oq8=
+github.com/homelight/json v1.13.0/go.mod h1:uTHhuUsgnrpm9cc7Gi3tfIUwgf1dq/7+uLfpUFLBFEQ=


### PR DESCRIPTION
Adds the ability to specify an encoder factory for outgoing JSON.

Motivation for this is https://github.com/golang/go/issues/27589 whereby nil slices marshal as `null` instead of `[]`.  There is a [fork which has the correct behavior](https://godoc.org/github.com/homelight/json#Encoder.SetNilSafeCollection) and with this PR in place you can configure the handler to use it.