### PR TITLE
Remove replace statement in go.mod

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,6 +2,4 @@ module github.com/chowey/jsonrpc
 
 go 1.13
 
-require github.com/helloeave/json v0.0.0-00010101000000-000000000000
-
-replace github.com/helloeave/json => github.com/homelight/json v1.13.0
+require github.com/helloeave/json v1.13.0

--- a/go.sum
+++ b/go.sum
@@ -1,2 +1,4 @@
+github.com/helloeave/json v1.13.0 h1:gCsw/v7D6c+zMxfa1fAOJsc1nRcW8oBH9OzfkONQj6E=
+github.com/helloeave/json v1.13.0/go.mod h1:uTHhuUsgnrpm9cc7Gi3tfIUwgf1dq/7+uLfpUFLBFEQ=
 github.com/homelight/json v1.13.0 h1:W1r5BUfQhgN6lGbu2YRXenSSPdbsJj8Gc+PV3PN+Oq8=
 github.com/homelight/json v1.13.0/go.mod h1:uTHhuUsgnrpm9cc7Gi3tfIUwgf1dq/7+uLfpUFLBFEQ=

--- a/go.sum
+++ b/go.sum
@@ -1,4 +1,2 @@
 github.com/helloeave/json v1.13.0 h1:gCsw/v7D6c+zMxfa1fAOJsc1nRcW8oBH9OzfkONQj6E=
 github.com/helloeave/json v1.13.0/go.mod h1:uTHhuUsgnrpm9cc7Gi3tfIUwgf1dq/7+uLfpUFLBFEQ=
-github.com/homelight/json v1.13.0 h1:W1r5BUfQhgN6lGbu2YRXenSSPdbsJj8Gc+PV3PN+Oq8=
-github.com/homelight/json v1.13.0/go.mod h1:uTHhuUsgnrpm9cc7Gi3tfIUwgf1dq/7+uLfpUFLBFEQ=


### PR DESCRIPTION
It's actually unnecessary and it forces projects that import this library to use the same replace statement.